### PR TITLE
Add (optional) unit_system option

### DIFF
--- a/lib/fitgem_oauth2/client.rb
+++ b/lib/fitgem_oauth2/client.rb
@@ -24,6 +24,7 @@ module FitgemOauth2
     attr_reader :client_secret
     attr_reader :token
     attr_reader :user_id
+    attr_reader :unit_system
 
     def initialize(opts)
       missing = [:client_id, :client_secret, :token] - opts.keys
@@ -35,7 +36,7 @@ module FitgemOauth2
       @client_secret = opts[:client_secret]
       @token = opts[:token]
       @user_id = (opts[:user_id] || DEFAULT_USER_ID)
-
+      @unit_system = opts[:unit_system]
       @connection = Faraday.new('https://api.fitbit.com')
     end
 
@@ -74,6 +75,7 @@ module FitgemOauth2
     def set_headers(request)
       request.headers['Authorization'] = "Bearer #{token}"
       request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+      request.headers['Accept-Language'] = unit_system unless unit_system == nil
     end
 
     def parse_response(response)

--- a/lib/fitgem_oauth2/version.rb
+++ b/lib/fitgem_oauth2/version.rb
@@ -1,3 +1,3 @@
 module FitgemOauth2
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -6,9 +6,10 @@ describe FitgemOauth2::Client do
   let(:client_secret) { 'secret' }
   let(:token) { 'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0MzAzNDM3MzUsInNjb3BlcyI6Indwcm8gd2xvYyB3bnV0IHdzbGUgd3NldCB3aHIgd3dlaSB3YWN0IHdzb2MiLCJzdWIiOiJBQkNERUYiLCJhdWQiOiJJSktMTU4iLCJpc3MiOiJGaXRiaXQiLCJ0eXAiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE0MzAzNDAxMzV9.z0VHrIEzjsBnjiNMBey6wtu26yHTnSWz_qlqoEpUlpc' }
   let(:user_id) { '26FWFL' }
+  let(:unit_system) { 'en_US' }
   let(:client) { FitgemOauth2::Client.new(opts) }
 
-  let(:opts) {{ client_id: client_id, client_secret: client_secret, token: token, user_id: user_id }}
+  let(:opts) {{ client_id: client_id, client_secret: client_secret, token: token, user_id: user_id, unit_system: unit_system }}
 
   describe '#initialize' do
 
@@ -17,11 +18,17 @@ describe FitgemOauth2::Client do
       expect(client.client_secret).to eq(client_secret)
       expect(client.token).to eq(token)
       expect(client.user_id).to eq(user_id)
+      expect(client.unit_system).to eq(unit_system)
     end
 
     it 'defaults user_id' do
       opts.delete(:user_id)
       expect(client.user_id).to eq(FitgemOauth2::Client::DEFAULT_USER_ID)
+    end
+
+    it 'defaults unit system' do
+      opts.delete(:unit_system)
+      expect(client.unit_system).to be_nil
     end
 
     it 'raises an error if client_id is missing' do


### PR DESCRIPTION
I've never done a pull request before, so please forgive me if something about this isn't right!  

This will allow users (like us) to set 'Accept-Language' to 'en_US' in the header of the fitbit api requests so that measurements will be returned in US units (specifically  pounds instead of kg)